### PR TITLE
Add data generator for chopping boards

### DIFF
--- a/src/generated/resources/data/hamncheese/chopping_boards/acacia_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/acacia_chopping_board.json
@@ -1,6 +1,7 @@
 {
   "pressurePlate": "minecraft:acacia_pressure_plate",
   "board": "hamncheese:acacia_chopping_board",
-  "sound": "block.wood.place",
-  "toolType": "axe"
+  "sound": "minecraft:block.wood.place",
+  "toolType": "axe",
+  "modId": "minecraft"
 }

--- a/src/generated/resources/data/hamncheese/chopping_boards/biomesoplenty/cherry_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/biomesoplenty/cherry_chopping_board.json
@@ -1,7 +1,7 @@
 {
   "pressurePlate": "biomesoplenty:cherry_pressure_plate",
   "board": "hamncheese:cherry_chopping_board",
-  "sound": "block.wood.place",
+  "sound": "minecraft:block.wood.place",
   "toolType": "axe",
   "modId": "biomesoplenty"
 }

--- a/src/generated/resources/data/hamncheese/chopping_boards/biomesoplenty/dead_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/biomesoplenty/dead_chopping_board.json
@@ -1,7 +1,7 @@
 {
   "pressurePlate": "biomesoplenty:dead_pressure_plate",
   "board": "hamncheese:dead_chopping_board",
-  "sound": "block.wood.place",
+  "sound": "minecraft:block.wood.place",
   "toolType": "axe",
   "modId": "biomesoplenty"
 }

--- a/src/generated/resources/data/hamncheese/chopping_boards/biomesoplenty/fir_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/biomesoplenty/fir_chopping_board.json
@@ -1,7 +1,7 @@
 {
   "pressurePlate": "biomesoplenty:fir_pressure_plate",
   "board": "hamncheese:fir_chopping_board",
-  "sound": "block.wood.place",
+  "sound": "minecraft:block.wood.place",
   "toolType": "axe",
   "modId": "biomesoplenty"
 }

--- a/src/generated/resources/data/hamncheese/chopping_boards/biomesoplenty/hellbark_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/biomesoplenty/hellbark_chopping_board.json
@@ -1,7 +1,7 @@
 {
   "pressurePlate": "biomesoplenty:hellbark_pressure_plate",
   "board": "hamncheese:hellbark_chopping_board",
-  "sound": "block.wood.place",
+  "sound": "minecraft:block.wood.place",
   "toolType": "axe",
   "modId": "biomesoplenty"
 }

--- a/src/generated/resources/data/hamncheese/chopping_boards/biomesoplenty/jacaranda_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/biomesoplenty/jacaranda_chopping_board.json
@@ -1,7 +1,7 @@
 {
   "pressurePlate": "biomesoplenty:jacaranda_pressure_plate",
   "board": "hamncheese:jacaranda_chopping_board",
-  "sound": "block.wood.place",
+  "sound": "minecraft:block.wood.place",
   "toolType": "axe",
   "modId": "biomesoplenty"
 }

--- a/src/generated/resources/data/hamncheese/chopping_boards/biomesoplenty/magic_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/biomesoplenty/magic_chopping_board.json
@@ -1,7 +1,7 @@
 {
   "pressurePlate": "biomesoplenty:magic_pressure_plate",
   "board": "hamncheese:magic_chopping_board",
-  "sound": "block.wood.place",
+  "sound": "minecraft:block.wood.place",
   "toolType": "axe",
   "modId": "biomesoplenty"
 }

--- a/src/generated/resources/data/hamncheese/chopping_boards/biomesoplenty/mahogany_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/biomesoplenty/mahogany_chopping_board.json
@@ -1,7 +1,7 @@
 {
   "pressurePlate": "biomesoplenty:mahogany_pressure_plate",
   "board": "hamncheese:mahogany_chopping_board",
-  "sound": "block.wood.place",
+  "sound": "minecraft:block.wood.place",
   "toolType": "axe",
   "modId": "biomesoplenty"
 }

--- a/src/generated/resources/data/hamncheese/chopping_boards/biomesoplenty/palm_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/biomesoplenty/palm_chopping_board.json
@@ -1,7 +1,7 @@
 {
   "pressurePlate": "biomesoplenty:palm_pressure_plate",
   "board": "hamncheese:palm_chopping_board",
-  "sound": "block.wood.place",
+  "sound": "minecraft:block.wood.place",
   "toolType": "axe",
   "modId": "biomesoplenty"
 }

--- a/src/generated/resources/data/hamncheese/chopping_boards/biomesoplenty/redwood_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/biomesoplenty/redwood_chopping_board.json
@@ -1,7 +1,7 @@
 {
   "pressurePlate": "biomesoplenty:redwood_pressure_plate",
   "board": "hamncheese:redwood_chopping_board",
-  "sound": "block.wood.place",
+  "sound": "minecraft:block.wood.place",
   "toolType": "axe",
   "modId": "biomesoplenty"
 }

--- a/src/generated/resources/data/hamncheese/chopping_boards/biomesoplenty/umbran_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/biomesoplenty/umbran_chopping_board.json
@@ -1,7 +1,7 @@
 {
   "pressurePlate": "biomesoplenty:umbran_pressure_plate",
   "board": "hamncheese:umbran_chopping_board",
-  "sound": "block.wood.place",
+  "sound": "minecraft:block.wood.place",
   "toolType": "axe",
   "modId": "biomesoplenty"
 }

--- a/src/generated/resources/data/hamncheese/chopping_boards/biomesoplenty/willow_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/biomesoplenty/willow_chopping_board.json
@@ -1,7 +1,7 @@
 {
   "pressurePlate": "biomesoplenty:willow_pressure_plate",
   "board": "hamncheese:willow_chopping_board",
-  "sound": "block.wood.place",
+  "sound": "minecraft:block.wood.place",
   "toolType": "axe",
   "modId": "biomesoplenty"
 }

--- a/src/generated/resources/data/hamncheese/chopping_boards/birch_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/birch_chopping_board.json
@@ -1,6 +1,7 @@
 {
   "pressurePlate": "minecraft:birch_pressure_plate",
   "board": "hamncheese:birch_chopping_board",
-  "sound": "block.wood.place",
-  "toolType": "axe"
+  "sound": "minecraft:block.wood.place",
+  "toolType": "axe",
+  "modId": "minecraft"
 }

--- a/src/generated/resources/data/hamncheese/chopping_boards/crimson_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/crimson_chopping_board.json
@@ -1,6 +1,7 @@
 {
   "pressurePlate": "minecraft:crimson_pressure_plate",
   "board": "hamncheese:crimson_chopping_board",
-  "sound": "block.wood.place",
-  "toolType": "axe"
+  "sound": "minecraft:block.wood.place",
+  "toolType": "axe",
+  "modId": "minecraft"
 }

--- a/src/generated/resources/data/hamncheese/chopping_boards/dark_oak_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/dark_oak_chopping_board.json
@@ -1,6 +1,7 @@
 {
   "pressurePlate": "minecraft:dark_oak_pressure_plate",
   "board": "hamncheese:dark_oak_chopping_board",
-  "sound": "block.wood.place",
-  "toolType": "axe"
+  "sound": "minecraft:block.wood.place",
+  "toolType": "axe",
+  "modId": "minecraft"
 }

--- a/src/generated/resources/data/hamncheese/chopping_boards/gold_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/gold_chopping_board.json
@@ -1,6 +1,7 @@
 {
   "pressurePlate": "minecraft:light_weighted_pressure_plate",
   "board": "hamncheese:gold_chopping_board",
-  "sound": "block.metal.place",
-  "toolType": "pickaxe"
+  "sound": "minecraft:block.metal.place",
+  "toolType": "pickaxe",
+  "modId": "minecraft"
 }

--- a/src/generated/resources/data/hamncheese/chopping_boards/iron_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/iron_chopping_board.json
@@ -1,6 +1,7 @@
 {
   "pressurePlate": "minecraft:heavy_weighted_pressure_plate",
   "board": "hamncheese:iron_chopping_board",
-  "sound": "block.metal.place",
-  "toolType": "pickaxe"
+  "sound": "minecraft:block.metal.place",
+  "toolType": "pickaxe",
+  "modId": "minecraft"
 }

--- a/src/generated/resources/data/hamncheese/chopping_boards/jungle_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/jungle_chopping_board.json
@@ -1,6 +1,7 @@
 {
   "pressurePlate": "minecraft:jungle_pressure_plate",
   "board": "hamncheese:jungle_chopping_board",
-  "sound": "block.wood.place",
-  "toolType": "axe"
+  "sound": "minecraft:block.wood.place",
+  "toolType": "axe",
+  "modId": "minecraft"
 }

--- a/src/generated/resources/data/hamncheese/chopping_boards/oak_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/oak_chopping_board.json
@@ -1,6 +1,7 @@
 {
   "pressurePlate": "minecraft:oak_pressure_plate",
   "board": "hamncheese:oak_chopping_board",
-  "sound": "block.wood.place",
-  "toolType": "axe"
+  "sound": "minecraft:block.wood.place",
+  "toolType": "axe",
+  "modId": "minecraft"
 }

--- a/src/generated/resources/data/hamncheese/chopping_boards/polished_blackstone_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/polished_blackstone_chopping_board.json
@@ -1,6 +1,7 @@
 {
   "pressurePlate": "minecraft:polished_blackstone_pressure_plate",
   "board": "hamncheese:polished_blackstone_chopping_board",
-  "sound": "block.stone.place",
-  "toolType": "pickaxe"
+  "sound": "minecraft:block.stone.place",
+  "toolType": "pickaxe",
+  "modId": "minecraft"
 }

--- a/src/generated/resources/data/hamncheese/chopping_boards/spruce_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/spruce_chopping_board.json
@@ -1,6 +1,7 @@
 {
   "pressurePlate": "minecraft:spruce_pressure_plate",
   "board": "hamncheese:spruce_chopping_board",
-  "sound": "block.wood.place",
-  "toolType": "axe"
+  "sound": "minecraft:block.wood.place",
+  "toolType": "axe",
+  "modId": "minecraft"
 }

--- a/src/generated/resources/data/hamncheese/chopping_boards/stone_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/stone_chopping_board.json
@@ -1,6 +1,7 @@
 {
   "pressurePlate": "minecraft:stone_pressure_plate",
   "board": "hamncheese:stone_chopping_board",
-  "sound": "block.stone.place",
-  "toolType": "pickaxe"
+  "sound": "minecraft:block.stone.place",
+  "toolType": "pickaxe",
+  "modId": "minecraft"
 }

--- a/src/generated/resources/data/hamncheese/chopping_boards/warped_chopping_board.json
+++ b/src/generated/resources/data/hamncheese/chopping_boards/warped_chopping_board.json
@@ -1,6 +1,7 @@
 {
   "pressurePlate": "minecraft:warped_pressure_plate",
   "board": "hamncheese:warped_chopping_board",
-  "sound": "block.wood.place",
-  "toolType": "axe"
+  "sound": "minecraft:block.wood.place",
+  "toolType": "axe",
+  "modId": "minecraft"
 }

--- a/src/main/java/coffeecatrailway/hamncheese/HNCMod.java
+++ b/src/main/java/coffeecatrailway/hamncheese/HNCMod.java
@@ -81,6 +81,7 @@ public class HNCMod
         generator.addProvider(new HNCRecipeGen(generator));
         generator.addProvider(new HNCItemModels(generator));
         generator.addProvider(new HNCBlockStates(generator, existingFileHelper));
+        generator.addProvider(new HNCChoppingBoards(generator));
     }
 
     public static ResourceLocation getLocation(String path)

--- a/src/main/java/coffeecatrailway/hamncheese/data/gen/HNCChoppingBoards.java
+++ b/src/main/java/coffeecatrailway/hamncheese/data/gen/HNCChoppingBoards.java
@@ -1,0 +1,106 @@
+package coffeecatrailway.hamncheese.data.gen;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.mojang.serialization.JsonOps;
+
+import biomesoplenty.api.block.BOPBlocks;
+import coffeecatrailway.hamncheese.HNCMod;
+import coffeecatrailway.hamncheese.data.ChoppingBoard;
+import coffeecatrailway.hamncheese.registry.HNCBlocks;
+import net.minecraft.block.Blocks;
+import net.minecraft.data.DataGenerator;
+import net.minecraft.data.DirectoryCache;
+import net.minecraft.data.IDataProvider;
+import net.minecraft.util.SoundEvents;
+
+/**
+ * @author vemerion
+ */
+public class HNCChoppingBoards implements IDataProvider {
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private Map<String, JsonElement> toSerialize = new HashMap<>();
+    private DataGenerator generator;
+
+    public HNCChoppingBoards(DataGenerator generator) {
+        this.generator = generator;
+    }
+
+    @Override
+    public void run(DirectoryCache cache) throws IOException {
+        Path folder = generator.getOutputFolder();
+        start();
+
+        toSerialize.forEach((name, json) -> {
+            Path path = folder.resolve("data/" + HNCMod.MOD_ID + "/chopping_boards/" + name + ".json");
+            try {
+                IDataProvider.save(GSON, cache, json, path);
+            } catch (IOException e) {
+                LOGGER.error("Couldn't save chopping board {}", path, e);
+            }
+        });
+    }
+
+    private void start() {
+        addChoppingBoard(new ChoppingBoard(BOPBlocks.cherry_pressure_plate, HNCBlocks.CHERRY_CHOPPING_BOARD.get(), SoundEvents.WOOD_PLACE, "axe"), "biomesoplenty");
+        addChoppingBoard(new ChoppingBoard(BOPBlocks.dead_pressure_plate, HNCBlocks.DEAD_CHOPPING_BOARD.get(), SoundEvents.WOOD_PLACE, "axe"), "biomesoplenty");
+        addChoppingBoard(new ChoppingBoard(BOPBlocks.fir_pressure_plate, HNCBlocks.FIR_CHOPPING_BOARD.get(), SoundEvents.WOOD_PLACE, "axe"), "biomesoplenty");
+        addChoppingBoard(new ChoppingBoard(BOPBlocks.hellbark_pressure_plate, HNCBlocks.HELLBARK_CHOPPING_BOARD.get(), SoundEvents.WOOD_PLACE, "axe"), "biomesoplenty");
+        addChoppingBoard(new ChoppingBoard(BOPBlocks.jacaranda_pressure_plate, HNCBlocks.JACARANDA_CHOPPING_BOARD.get(), SoundEvents.WOOD_PLACE, "axe"), "biomesoplenty");
+        addChoppingBoard(new ChoppingBoard(BOPBlocks.magic_pressure_plate, HNCBlocks.MAGIC_CHOPPING_BOARD.get(), SoundEvents.WOOD_PLACE, "axe"), "biomesoplenty");
+        addChoppingBoard(new ChoppingBoard(BOPBlocks.mahogany_pressure_plate, HNCBlocks.MAHOGANY_CHOPPING_BOARD.get(), SoundEvents.WOOD_PLACE, "axe"), "biomesoplenty");
+        addChoppingBoard(new ChoppingBoard(BOPBlocks.palm_pressure_plate, HNCBlocks.PALM_CHOPPING_BOARD.get(), SoundEvents.WOOD_PLACE, "axe"), "biomesoplenty");
+        addChoppingBoard(new ChoppingBoard(BOPBlocks.redwood_pressure_plate, HNCBlocks.REDWOOD_CHOPPING_BOARD.get(), SoundEvents.WOOD_PLACE, "axe"), "biomesoplenty");
+        addChoppingBoard(new ChoppingBoard(BOPBlocks.umbran_pressure_plate, HNCBlocks.UMBRAN_CHOPPING_BOARD.get(), SoundEvents.WOOD_PLACE, "axe"), "biomesoplenty");
+        addChoppingBoard(new ChoppingBoard(BOPBlocks.willow_pressure_plate, HNCBlocks.WILLOW_CHOPPING_BOARD.get(), SoundEvents.WOOD_PLACE, "axe"), "biomesoplenty");
+        
+        addChoppingBoard(new ChoppingBoard(Blocks.ACACIA_PRESSURE_PLATE, HNCBlocks.ACACIA_CHOPPING_BOARD.get(), SoundEvents.WOOD_PLACE, "axe"));
+        addChoppingBoard(new ChoppingBoard(Blocks.BIRCH_PRESSURE_PLATE, HNCBlocks.BIRCH_CHOPPING_BOARD.get(), SoundEvents.WOOD_PLACE, "axe"));
+        addChoppingBoard(new ChoppingBoard(Blocks.CRIMSON_PRESSURE_PLATE, HNCBlocks.CRIMSON_CHOPPING_BOARD.get(), SoundEvents.WOOD_PLACE, "axe"));
+        addChoppingBoard(new ChoppingBoard(Blocks.DARK_OAK_PRESSURE_PLATE, HNCBlocks.DARK_OAK_CHOPPING_BOARD.get(), SoundEvents.WOOD_PLACE, "axe"));
+        addChoppingBoard(new ChoppingBoard(Blocks.LIGHT_WEIGHTED_PRESSURE_PLATE, HNCBlocks.GOLD_CHOPPING_BOARD.get(), SoundEvents.METAL_PLACE, "pickaxe"));
+        addChoppingBoard(new ChoppingBoard(Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE, HNCBlocks.IRON_CHOPPING_BOARD.get(), SoundEvents.METAL_PLACE, "pickaxe"));
+        addChoppingBoard(new ChoppingBoard(Blocks.JUNGLE_PRESSURE_PLATE, HNCBlocks.JUNGLE_CHOPPING_BOARD.get(), SoundEvents.WOOD_PLACE, "axe"));
+        addChoppingBoard(new ChoppingBoard(Blocks.OAK_PRESSURE_PLATE, HNCBlocks.OAK_CHOPPING_BOARD.get(), SoundEvents.WOOD_PLACE, "axe"));
+        addChoppingBoard(new ChoppingBoard(Blocks.POLISHED_BLACKSTONE_PRESSURE_PLATE, HNCBlocks.POLISHED_BLACKSTONE_CHOPPING_BOARD.get(), SoundEvents.STONE_PLACE, "pickaxe"));
+        addChoppingBoard(new ChoppingBoard(Blocks.SPRUCE_PRESSURE_PLATE, HNCBlocks.SPRUCE_CHOPPING_BOARD.get(), SoundEvents.WOOD_PLACE, "axe"));
+        addChoppingBoard(new ChoppingBoard(Blocks.STONE_PRESSURE_PLATE, HNCBlocks.STONE_CHOPPING_BOARD.get(), SoundEvents.STONE_PLACE, "pickaxe"));
+        addChoppingBoard(new ChoppingBoard(Blocks.WARPED_PRESSURE_PLATE, HNCBlocks.WARPED_CHOPPING_BOARD.get(), SoundEvents.WOOD_PLACE, "axe"));
+
+    }
+
+    private void addChoppingBoard(ChoppingBoard board) {
+        addChoppingBoard(board, "minecraft");
+    }
+
+    private void addChoppingBoard(ChoppingBoard board, String modid) {
+        Optional<JsonElement> opt = JsonOps.INSTANCE.withEncoder(ChoppingBoard.CODEC).apply(board).result();
+        if (opt.isPresent() && opt.get().isJsonObject()) {
+            JsonObject json = opt.get().getAsJsonObject();
+            json.addProperty("modId", modid);
+            String name = board.getBoard().getRegistryName().getPath();
+            toSerialize.put((modid.equals("minecraft") ? "" : modid + "/") + name, json);
+        } else {
+            LOGGER.error("Couldn't save chopping board {}", board);
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "Chopping Boards: " + HNCMod.MOD_ID;
+    }
+
+}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -42,4 +42,3 @@ mandatory=false
 versionRange="[1.16.5-13,]"
 ordering="AFTER"
 side="BOTH"
-side="CLIENT"


### PR DESCRIPTION
This change adds a custom data generator for chopping boards, to avoid
the need for manual creation of the json files.

Note that I also had to make a small change to the mods.toml file to get
the mod to run.